### PR TITLE
New Dockerfile using alpine-golang-make-onbuild base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM        sdurrheimer/alpine-golang-make-onbuild
+MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
+
+EXPOSE     9110

--- a/Makefile.COMMON
+++ b/Makefile.COMMON
@@ -49,19 +49,22 @@ ifeq ($(GOOS),darwin)
 endif
 
 GO_VERSION ?= 1.4.2
-
-ifeq ($(shell type go >/dev/null && go version | sed 's/.*go\([0-9.]*\).*/\1/'), $(GO_VERSION))
-	GOROOT := $(shell go env GOROOT)
-else
-	GOROOT := $(CURDIR)/.build/go$(GO_VERSION)
-endif
-
 GOURL      ?= https://golang.org/dl
 GOPKG      ?= go$(GO_VERSION).$(GOOS)-$(GOARCH)$(RELEASE_SUFFIX).tar.gz
 GOPATH     := $(CURDIR)/.build/gopath
-GOCC       ?= $(GOROOT)/bin/go
-GO         ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
-GOFMT      ?= $(GOROOT)/bin/gofmt
+
+# Check for the correct version of go in the path. If we find it, use it.
+# Otherwise, prepare to build go locally.
+ifeq ($(shell command -v "go" >/dev/null && go version | sed -e 's/^[^0-9.]*\([0-9.]*\).*/\1/'), $(GO_VERSION))
+	GOCC   ?= $(shell command -v "go")
+	GOFMT  ?= $(shell command -v "gofmt")
+	GO     ?= GOPATH=$(GOPATH) $(GOCC)
+else
+	GOROOT ?= $(CURDIR)/.build/go$(GO_VERSION)
+	GOCC   ?= $(GOROOT)/bin/go
+	GOFMT  ?= $(GOROOT)/bin/gofmt
+	GO     ?= GOROOT=$(GOROOT) GOPATH=$(GOPATH) $(GOCC)
+endif
 
 # Never honor GOBIN, should it be set at all.
 unexport GOBIN
@@ -98,7 +101,7 @@ $(BINARY): $(GOCC) $(SRC) dependencies-stamp Makefile Makefile.COMMON
 archive: $(ARCHIVE)
 
 $(ARCHIVE): $(BINARY)
-	tar -czf $@ $<
+	tar -owner=root --group=root -czf $@ $<
 
 .PHONY: tag
 tag:

--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ Execute `ping`. Port and path are ignored.
       -u icmp://192.168.178.1 \
       -u tcp://freigeist.org:655
 
+## Using Docker
+
+    docker pull fish/blackbox-prober
+
+    docker run -d -p 9110:9110 fish/blackbox-prober \
+        -u http://5pi.de \
+        -u https://5pi.de \
+        -u icmp://192.168.178.1 \
+        -u tcp://freigeist.org:655


### PR DESCRIPTION
Following the docker related PR series.

New Dockerfile using the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild) base image whose goal is to unified the way to dockerize prometheus tools and exporters based on Golang.

The binary is build using make. (Golang is installed via make too, respecting the GO_VERSION).

A testable image is available under my name on Docker hub : [Link](https://registry.hub.docker.com/u/sdurrheimer/blackbox-prober/)

I have also added some Docker usage instructions in the readme.

As always, the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild)  image can be also move under Prometheus organization.

@discordianfish 
